### PR TITLE
Add onTouchesBegan and onTouchesEnded

### DIFF
--- a/ios/BrightcovePlayer.h
+++ b/ios/BrightcovePlayer.h
@@ -41,6 +41,8 @@
 @property (nonatomic, copy) RCTDirectEventBlock onUpdateBufferProgress;
 @property (nonatomic, copy) RCTDirectEventBlock onEnterFullscreen;
 @property (nonatomic, copy) RCTDirectEventBlock onExitFullscreen;
+@property (nonatomic, copy) RCTDirectEventBlock onTouchesBegan;
+@property (nonatomic, copy) RCTDirectEventBlock onTouchesEnded;
 
 -(void) seekTo:(NSNumber *)time;
 -(void)dispose;

--- a/ios/BrightcovePlayer.h
+++ b/ios/BrightcovePlayer.h
@@ -43,8 +43,6 @@
 @property (nonatomic, copy) RCTDirectEventBlock onExitFullscreen;
 @property (nonatomic, copy) RCTDirectEventBlock onTouchesBegan;
 @property (nonatomic, copy) RCTDirectEventBlock onTouchesEnded;
-@property (nonatomic, copy) RCTDirectEventBlock onTap;
-@property (nonatomic, copy) RCTDirectEventBlock onDoubleTap;
 
 -(void) seekTo:(NSNumber *)time;
 -(void)dispose;

--- a/ios/BrightcovePlayer.h
+++ b/ios/BrightcovePlayer.h
@@ -43,6 +43,8 @@
 @property (nonatomic, copy) RCTDirectEventBlock onExitFullscreen;
 @property (nonatomic, copy) RCTDirectEventBlock onTouchesBegan;
 @property (nonatomic, copy) RCTDirectEventBlock onTouchesEnded;
+@property (nonatomic, copy) RCTDirectEventBlock onTap;
+@property (nonatomic, copy) RCTDirectEventBlock onDoubleTap;
 
 -(void) seekTo:(NSNumber *)time;
 -(void)dispose;

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -257,13 +257,29 @@
 #pragma mark UIView Methods
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    NSLog("touches began");
-    self.onTouchesBegan();
+    [super touchesBegan:touches withEvent:event];
+    if (self.onTouchesBegan) {
+        self.onTouchesBegan(@{});
+    }
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [super touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    NSLog("touches ended");
-    self.onTouchesEnded();
+    [super touchesEnded:touches withEvent:event];
+    if (self.onTouchesEnded) {
+        self.onTouchesEnded(@{});
+    }
 }
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [super touchesCancelled:touches withEvent:event];
+    if (self.onTouchesEnded) {
+        self.onTouchesEnded(@{});
+    }
+}
+
 
 @end

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -33,6 +33,15 @@
                                               [_playerViewController.view.leftAnchor constraintEqualToAnchor:self.leftAnchor],
                                               [_playerViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
                                               ]];
+    
+    // Add Gesture Recognizers
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap:)];
+    tap.numberOfTapsRequired = 1;
+    [self addGestureRecognizer:tap];
+    
+    UITapGestureRecognizer *doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(doubleTap:)];
+    doubleTap.numberOfTapsRequired = 2;
+    [self addGestureRecognizer:doubleTap];
 
     _targetVolume = 1.0;
     _autoPlay = NO;
@@ -281,5 +290,16 @@
     }
 }
 
+- (void)tap: (UITapGestureRecognizer *)gesture {
+    if(self.onTap) {
+        self.onTap(@{});
+    }
+}
+
+- (void)doubleTap: (UITapGestureRecognizer *)gesture {
+    if(self.onDoubleTap) {
+        self.onDoubleTap(@{});
+    }
+}
 
 @end

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -269,14 +269,16 @@
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [super touchesEnded:touches withEvent:event];
     if (self.onTouchesEnded) {
-        self.onTouchesEnded(@{@"tapCount" : @([touches anyObject].tapCount)});
+        NSUInteger taps = [[[event allTouches] anyObject] tapCount];
+        self.onTouchesEnded(@{@"tapCount" : @(taps)});
     }
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [super touchesCancelled:touches withEvent:event];
     if (self.onTouchesEnded) {
-        self.onTouchesEnded(@{@"tapCount" : @([touches anyObject].tapCount)});
+        NSUInteger taps = [[[event allTouches] anyObject] tapCount];
+        self.onTouchesEnded(@{@"tapCount" : @(taps)});
     }
 }
 

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -254,4 +254,16 @@
     [self.playbackController setVideos:@[]];
 }
 
+#pragma mark UIView Methods
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    NSLog("touches began");
+    self.onTouchesBegan();
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    NSLog("touches ended");
+    self.onTouchesEnded();
+}
+
 @end

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -33,16 +33,6 @@
                                               [_playerViewController.view.leftAnchor constraintEqualToAnchor:self.leftAnchor],
                                               [_playerViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
                                               ]];
-    
-    // Add Gesture Recognizers
-    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap:)];
-    tap.numberOfTapsRequired = 1;
-    [self addGestureRecognizer:tap];
-    
-    UITapGestureRecognizer *doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(doubleTap:)];
-    doubleTap.numberOfTapsRequired = 2;
-    [self addGestureRecognizer:doubleTap];
-
     _targetVolume = 1.0;
     _autoPlay = NO;
 }
@@ -279,26 +269,14 @@
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [super touchesEnded:touches withEvent:event];
     if (self.onTouchesEnded) {
-        self.onTouchesEnded(@{});
+        self.onTouchesEnded(@{@"tapCount" : @([touches anyObject].tapCount)});
     }
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [super touchesCancelled:touches withEvent:event];
     if (self.onTouchesEnded) {
-        self.onTouchesEnded(@{});
-    }
-}
-
-- (void)tap: (UITapGestureRecognizer *)gesture {
-    if(self.onTap) {
-        self.onTap(@{});
-    }
-}
-
-- (void)doubleTap: (UITapGestureRecognizer *)gesture {
-    if(self.onDoubleTap) {
-        self.onDoubleTap(@{});
+        self.onTouchesEnded(@{@"tapCount" : @([touches anyObject].tapCount)});
     }
 }
 

--- a/ios/BrightcovePlayerManager.m
+++ b/ios/BrightcovePlayerManager.m
@@ -37,6 +37,8 @@ RCT_EXPORT_VIEW_PROPERTY(onChangeDuration, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onUpdateBufferProgress, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onEnterFullscreen, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onExitFullscreen, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onTouchesBegan, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onTouchesEnded, RCTDirectEventBlock);
 
 RCT_EXPORT_METHOD(seekTo:(nonnull NSNumber *)reactTag seconds:(nonnull NSNumber *)seconds) {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -82,14 +82,6 @@ class BrightcovePlayer extends Component {
           this.props.onTouchesEnded &&
           this.props.onTouchesEnded(event.nativeEvent)
         }
-        onTap={event =>
-          this.props.onTap &&
-          this.props.onTap(event.nativeEvent)
-        }
-        onDoubleTap={event =>
-          this.props.onDoubleTap &&
-          this.props.onDoubleTap(event.nativeEvent)
-        }
         onToggleAndroidFullscreen={event => {
           const fullscreen =
             typeof event.nativeEvent.fullscreen === 'boolean'
@@ -151,9 +143,7 @@ BrightcovePlayer.propTypes = {
   onEnterFullscreen: PropTypes.func,
   onExitFullscreen: PropTypes.func,
   onTouchesBegan: PropTypes.func,
-  onTouchesEnded: PropTypes.func,
-  onTap: PropTypes.func,
-  onDoubleTap: PropTypes.func
+  onTouchesEnded: PropTypes.func
 };
 
 BrightcovePlayer.defaultProps = {};

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -82,6 +82,14 @@ class BrightcovePlayer extends Component {
           this.props.onTouchesEnded &&
           this.props.onTouchesEnded(event.nativeEvent)
         }
+        onTap={event =>
+          this.props.onTap &&
+          this.props.onTap(event.nativeEvent)
+        }
+        onDoubleTap={event =>
+          this.props.onDoubleTap &&
+          this.props.onDoubleTap(event.nativeEvent)
+        }
         onToggleAndroidFullscreen={event => {
           const fullscreen =
             typeof event.nativeEvent.fullscreen === 'boolean'
@@ -143,7 +151,9 @@ BrightcovePlayer.propTypes = {
   onEnterFullscreen: PropTypes.func,
   onExitFullscreen: PropTypes.func,
   onTouchesBegan: PropTypes.func,
-  onTouchesEnded: PropTypes.func
+  onTouchesEnded: PropTypes.func,
+  onTap: PropTypes.func,
+  onDoubleTap: PropTypes.func
 };
 
 BrightcovePlayer.defaultProps = {};

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -74,6 +74,14 @@ class BrightcovePlayer extends Component {
           this.props.onExitFullscreen &&
           this.props.onExitFullscreen(event.nativeEvent)
         }
+        onTouchesBegan={event =>
+          this.props.onTouchesBegan &&
+          this.props.onTouchesBegan(event.nativeEvent)
+        }
+        onTouchesEnded={event =>
+          this.props.onTouchesEnded &&
+          this.props.onTouchesEnded(event.nativeEvent)
+        }
         onToggleAndroidFullscreen={event => {
           const fullscreen =
             typeof event.nativeEvent.fullscreen === 'boolean'
@@ -133,7 +141,9 @@ BrightcovePlayer.propTypes = {
   onChangeDuration: PropTypes.func,
   onUpdateBufferProgress: PropTypes.func,
   onEnterFullscreen: PropTypes.func,
-  onExitFullscreen: PropTypes.func
+  onExitFullscreen: PropTypes.func,
+  onTouchesBegan: PropTypes.func,
+  onTouchesEnded: PropTypes.func
 };
 
 BrightcovePlayer.defaultProps = {};


### PR DESCRIPTION
This PR adds `onTouchesBegan` and `onTouchesEnded` that can be used to detect when the user begins interacting with the video player.

Notes:
- This functionality was required to match the control state for our custom close button on iOS.
- If this behavior is needed for Android then we will need additional work to be done to the Native Android implementation.