### PR TITLE
Support for detecting when controls hide / show on iOS and Android

### DIFF
--- a/android/src/main/java/jp/manse/BrightcovePlayerManager.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerManager.java
@@ -25,6 +25,8 @@ public class BrightcovePlayerManager extends SimpleViewManager<BrightcovePlayerV
     public static final String EVENT_TOGGLE_ANDROID_FULLSCREEN = "toggle_android_fullscreen";
     public static final String EVENT_CHANGE_DURATION = "change_duration";
     public static final String EVENT_UPDATE_BUFFER_PROGRESS = "update_buffer_progress";
+    public static final String EVENT_SHOW_MEDIA_CONTROLS = "show_media_controls";
+    public static final String EVENT_HIDE_MEDIA_CONTROLS = "hide_media_controls";
 
     private ReactApplicationContext applicationContext;
 
@@ -104,11 +106,6 @@ public class BrightcovePlayerManager extends SimpleViewManager<BrightcovePlayerV
         view.setFullscreen(fullscreen);
     }
 
-    @ReactProp(name = "simulateLandscape")
-    public void setSimulateLandscape(BrightcovePlayerView view, boolean isSimulateLandscape) {
-        view.setSimulateLandscape(isSimulateLandscape);
-    }
-
     @Override
     public Map<String, Integer> getCommandsMap() {
         return MapBuilder.of(
@@ -140,6 +137,8 @@ public class BrightcovePlayerManager extends SimpleViewManager<BrightcovePlayerV
         map.put(EVENT_CHANGE_DURATION, (Object) MapBuilder.of("registrationName", "onChangeDuration"));
         map.put(EVENT_UPDATE_BUFFER_PROGRESS, (Object) MapBuilder.of("registrationName", "onUpdateBufferProgress"));
         map.put(EVENT_TOGGLE_ANDROID_FULLSCREEN, (Object) MapBuilder.of("registrationName", "onToggleAndroidFullscreen"));
+        map.put(EVENT_SHOW_MEDIA_CONTROLS, (Object) MapBuilder.of("registrationName", "onShowMediaControls"));
+        map.put(EVENT_HIDE_MEDIA_CONTROLS, (Object) MapBuilder.of("registrationName", "onHideMediaControls"));
         return map;
     }
 }

--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -75,13 +75,32 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
 
         this.playerVideoView = new BrightcoveExoPlayerTextureVideoView(this.context);
         this.addView(this.playerVideoView);
-        this.playerVideoView.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
+        this.playerVideoView.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
         this.playerVideoView.finishInitialization();
         this.mediaController = new BrightcoveMediaController(this.playerVideoView);
         this.playerVideoView.setMediaController(this.mediaController);
         this.requestLayout();
 
         EventEmitter eventEmitter = this.playerVideoView.getEventEmitter();
+        //Event sent when we know the Video dimensions.
+        eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
+            @Override
+            public void processEvent(Event event) {
+                // Get the width and height
+                float width = event.getIntegerProperty(Event.VIDEO_WIDTH);
+                float height = event.getIntegerProperty(Event.VIDEO_HEIGHT);
+                float aspectRatio = height/width;
+
+                //Get the display metrics
+                DisplayMetrics metrics = new DisplayMetrics();
+                getWindowManager().getDefaultDisplay().getMetrics(metrics);
+                int videoWidth = metrics.widthPixels; // We cover the entire display's width
+                int videoHeight = (int) (videoWidth*aspectRatio); //Calculate the height based on the ratio
+
+                // Set the layout params (In this example the BrightcoveVideoView was held inside a LinearLayout).
+                this.playerVideoView.setLayoutParams(new LinearLayout.LayoutParams(videoWidth,videoHeight));
+            }
+        });
         eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
             @Override
             public void processEvent(Event e) {

--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -75,7 +75,7 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
 
         this.playerVideoView = new BrightcoveExoPlayerTextureVideoView(this.context);
         this.addView(this.playerVideoView);
-        this.playerVideoView.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+        this.playerVideoView.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
         this.playerVideoView.finishInitialization();
         this.mediaController = new BrightcoveMediaController(this.playerVideoView);
         this.playerVideoView.setMediaController(this.mediaController);

--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -81,26 +81,27 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
         this.playerVideoView.setMediaController(this.mediaController);
         this.requestLayout();
 
-        EventEmitter eventEmitter = this.playerVideoView.getEventEmitter();
+//        EventEmitter eventEmitter = this.playerVideoView.getEventEmitter();
+//        eventEmitter.emit(EventType.ENTER_FULL_SCREEN);
         //Event sent when we know the Video dimensions.
-        eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
-            @Override
-            public void processEvent(Event event) {
-                // Get the width and height
-                float width = event.getIntegerProperty(Event.VIDEO_WIDTH);
-                float height = event.getIntegerProperty(Event.VIDEO_HEIGHT);
-                float aspectRatio = height/width;
-
-                //Get the display metrics
-                DisplayMetrics metrics = new DisplayMetrics();
-                getWindowManager().getDefaultDisplay().getMetrics(metrics);
-                int videoWidth = metrics.widthPixels; // We cover the entire display's width
-                int videoHeight = (int) (videoWidth*aspectRatio); //Calculate the height based on the ratio
-
-                // Set the layout params (In this example the BrightcoveVideoView was held inside a LinearLayout).
-                this.playerVideoView.setLayoutParams(new LinearLayout.LayoutParams(videoWidth,videoHeight));
-            }
-        });
+//        eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
+//            @Override
+//            public void processEvent(Event event) {
+//                // Get the width and height
+//                float width = event.getIntegerProperty(Event.VIDEO_WIDTH);
+//                float height = event.getIntegerProperty(Event.VIDEO_HEIGHT);
+//                float aspectRatio = height/width;
+//
+//                //Get the display metrics
+//                DisplayMetrics metrics = new DisplayMetrics();
+//                getWindowManager().getDefaultDisplay().getMetrics(metrics);
+//                int videoWidth = metrics.widthPixels; // We cover the entire display's width
+//                int videoHeight = (int) (videoWidth*aspectRatio); //Calculate the height based on the ratio
+//
+//                // Set the layout params (In this example the BrightcoveVideoView was held inside a LinearLayout).
+//                this.setLayoutParams(new LinearLayout.LayoutParams(videoWidth,videoHeight));
+//            }
+//        });
         eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
             @Override
             public void processEvent(Event e) {
@@ -398,17 +399,17 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
 
         }
         else {
-            surfaceView.setTransform(null);
-
-            int viewWidth = this.getMeasuredWidth();
-            int viewHeight = this.getMeasuredHeight();
-
-            surfaceView.measure(viewWidth, viewHeight);
-            int surfaceWidth = surfaceView.getMeasuredWidth();
-            int surfaceHeight = surfaceView.getMeasuredHeight();
-            int leftOffset = (viewWidth - surfaceWidth) / 2;
-            int topOffset = (viewHeight - surfaceHeight) / 2;
-            surfaceView.layout(leftOffset, topOffset, leftOffset + surfaceWidth, topOffset + surfaceHeight);
+//            surfaceView.setTransform(null);
+//
+//            int viewWidth = this.getMeasuredWidth();
+//            int viewHeight = this.getMeasuredHeight();
+//
+//            surfaceView.measure(viewWidth, viewHeight);
+//            int surfaceWidth = surfaceView.getMeasuredWidth();
+//            int surfaceHeight = surfaceView.getMeasuredHeight();
+//            int leftOffset = (viewWidth - surfaceWidth) / 2;
+//            int topOffset = (viewHeight - surfaceHeight) / 2;
+//            surfaceView.layout(leftOffset, topOffset, leftOffset + surfaceWidth, topOffset + surfaceHeight);
         }
     }
 

--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -44,6 +44,9 @@ import com.google.android.exoplayer2.trackselection.FixedTrackSelection;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 
+import static com.brightcove.player.mediacontroller.ShowHideController.SHOW_MEDIA_CONTROLS;
+import static com.brightcove.player.mediacontroller.ShowHideController.HIDE_MEDIA_CONTROLS;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -81,31 +84,27 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
         this.playerVideoView.setMediaController(this.mediaController);
         this.requestLayout();
 
-//        EventEmitter eventEmitter = this.playerVideoView.getEventEmitter();
-//        eventEmitter.emit(EventType.ENTER_FULL_SCREEN);
-        //Event sent when we know the Video dimensions.
-//        eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
-//            @Override
-//            public void processEvent(Event event) {
-//                // Get the width and height
-//                float width = event.getIntegerProperty(Event.VIDEO_WIDTH);
-//                float height = event.getIntegerProperty(Event.VIDEO_HEIGHT);
-//                float aspectRatio = height/width;
-//
-//                //Get the display metrics
-//                DisplayMetrics metrics = new DisplayMetrics();
-//                getWindowManager().getDefaultDisplay().getMetrics(metrics);
-//                int videoWidth = metrics.widthPixels; // We cover the entire display's width
-//                int videoHeight = (int) (videoWidth*aspectRatio); //Calculate the height based on the ratio
-//
-//                // Set the layout params (In this example the BrightcoveVideoView was held inside a LinearLayout).
-//                this.setLayoutParams(new LinearLayout.LayoutParams(videoWidth,videoHeight));
-//            }
-//        });
+        EventEmitter eventEmitter = this.playerVideoView.getEventEmitter();
+        eventEmitter.on(SHOW_MEDIA_CONTROLS, new EventListener() {
+            @Override
+            public void processEvent(Event e) {
+                WritableMap event = Arguments.createMap();
+                ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
+                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(), BrightcovePlayerManager.EVENT_SHOW_MEDIA_CONTROLS, event);
+            }
+        });
+        eventEmitter.on(HIDE_MEDIA_CONTROLS, new EventListener() {
+            @Override
+            public void processEvent(Event e) {
+                WritableMap event = Arguments.createMap();
+                ReactContext reactContext = (ReactContext) BrightcovePlayerView.this.getContext();
+                reactContext.getJSModule(RCTEventEmitter.class).receiveEvent(BrightcovePlayerView.this.getId(), BrightcovePlayerManager.EVENT_HIDE_MEDIA_CONTROLS, event);
+            }
+        });
         eventEmitter.on(EventType.VIDEO_SIZE_KNOWN, new EventListener() {
             @Override
             public void processEvent(Event e) {
-                fixVideoLayout();
+                fixVideoLayout(e);
                 updateBitRate();
                 updatePlaybackRate();
             }
@@ -219,14 +218,6 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
     public void setVideoToken(String videoToken) {
         this.videoToken = videoToken;
         this.loadVideo();
-    }
-
-    public void setSimulateLandscape(boolean isSimulateLandscape) {
-        boolean previousValue = this.simulateLandscape;
-        this.simulateLandscape = isSimulateLandscape;
-        if (playing && isSimulateLandscape ^ previousValue) {
-            fixVideoLayout();
-        }
     }
 
     public void setAutoPlay(boolean autoPlay) {
@@ -368,49 +359,22 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
         }
     }
 
-    private void fixVideoLayout() {
+    private void fixVideoLayout(Event e) {
 
         TextureView surfaceView = (TextureView) playerVideoView.getRenderView();
+        surfaceView.setTransform(null);
 
-        if (simulateLandscape) {
+        // Get the width and height of the video
+        float width = e.getIntegerProperty(Event.VIDEO_WIDTH);
+        float height = e.getIntegerProperty(Event.VIDEO_HEIGHT);
+        float aspectRatio = width/height;
 
-            int viewWidth = this.getMeasuredWidth();
-            int viewHeight = this.getMeasuredHeight();
-            surfaceView.layout(0, 0, viewWidth, viewHeight);
+        // Get height of view and resize surface to fill view's height
+        int viewHeight = this.getMeasuredHeight();
+        int videoWidth = (int) (viewHeight * aspectRatio);
+        int videoHeight = viewHeight; // We cover the entire display's height
 
-            // scale 1  (ww / vw)
-            // scale 2 (wh / scale 1)
-            RenderView renderView = playerVideoView.getRenderView();
-
-            float pX = getWidth() / 2.0f;
-            float pY = getHeight() / 2.0f;
-
-            Matrix undoDefaultStretchAndRotate = new Matrix();
-            undoDefaultStretchAndRotate.setScale(1.0f,
-                    (1.0f / ((getHeight() / (float) getWidth()))) * (renderView.getVideoHeight() / (float) renderView.getVideoWidth()),
-                    pX,
-                    pY);
-
-            undoDefaultStretchAndRotate.postRotate(90, pX, pY);
-            undoDefaultStretchAndRotate.postScale(getHeight() / (float) getWidth(),
-                    getHeight() / (float) getWidth(), pX, pY);
-
-            surfaceView.setTransform(undoDefaultStretchAndRotate);
-
-        }
-        else {
-//            surfaceView.setTransform(null);
-//
-//            int viewWidth = this.getMeasuredWidth();
-//            int viewHeight = this.getMeasuredHeight();
-//
-//            surfaceView.measure(viewWidth, viewHeight);
-//            int surfaceWidth = surfaceView.getMeasuredWidth();
-//            int surfaceHeight = surfaceView.getMeasuredHeight();
-//            int leftOffset = (viewWidth - surfaceWidth) / 2;
-//            int topOffset = (viewHeight - surfaceHeight) / 2;
-//            surfaceView.layout(leftOffset, topOffset, leftOffset + surfaceWidth, topOffset + surfaceHeight);
-        }
+        surfaceView.layout(0, 0, videoWidth, videoHeight);
     }
 
     private void printKeys(Map<String, Object> map) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,10 @@ export type BrightcovePlayerProps = {
   onUpdateBufferProgress?: ({ bufferProgress: number }) => void;
   onEnterFullscreen?: () => void;
   onExitFullscreen?: () => void;
+  onTouchesBegan?: () => void;
+  onTouchesEnded?: ({tapCount: number}) => void;
+  onShowMediaControls?: () => void;
+  onHideMediaControls?: () => void;
   style?: ViewStyle;
 };
 

--- a/ios/BrightcovePlayer.h
+++ b/ios/BrightcovePlayer.h
@@ -41,6 +41,8 @@
 @property (nonatomic, copy) RCTDirectEventBlock onUpdateBufferProgress;
 @property (nonatomic, copy) RCTDirectEventBlock onEnterFullscreen;
 @property (nonatomic, copy) RCTDirectEventBlock onExitFullscreen;
+@property (nonatomic, copy) RCTDirectEventBlock onTouchesBegan;
+@property (nonatomic, copy) RCTDirectEventBlock onTouchesEnded;
 
 -(void) seekTo:(NSNumber *)time;
 -(void)dispose;

--- a/ios/BrightcovePlayer.h
+++ b/ios/BrightcovePlayer.h
@@ -43,8 +43,6 @@
 @property (nonatomic, copy) RCTDirectEventBlock onExitFullscreen;
 @property (nonatomic, copy) RCTDirectEventBlock onTouchesBegan;
 @property (nonatomic, copy) RCTDirectEventBlock onTouchesEnded;
-@property (nonatomic, copy) RCTDirectEventBlock onTap;
-@property (nonatomic, copy) RCTDirectEventBlock onDoubleTap;
 
 -(void) seekTo:(NSNumber *)time;
 -(void)dispose;

--- a/ios/BrightcovePlayer.h
+++ b/ios/BrightcovePlayer.h
@@ -43,6 +43,8 @@
 @property (nonatomic, copy) RCTDirectEventBlock onExitFullscreen;
 @property (nonatomic, copy) RCTDirectEventBlock onTouchesBegan;
 @property (nonatomic, copy) RCTDirectEventBlock onTouchesEnded;
+@property (nonatomic, copy) RCTDirectEventBlock onTap;
+@property (nonatomic, copy) RCTDirectEventBlock onDoubleTap;
 
 -(void) seekTo:(NSNumber *)time;
 -(void)dispose;

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -257,13 +257,29 @@
 #pragma mark UIView Methods
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    NSLog("touches began");
-    self.onTouchesBegan();
+    [super touchesBegan:touches withEvent:event];
+    if (self.onTouchesBegan) {
+        self.onTouchesBegan(@{});
+    }
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [super touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
-    NSLog("touches ended");
-    self.onTouchesEnded();
+    [super touchesEnded:touches withEvent:event];
+    if (self.onTouchesEnded) {
+        self.onTouchesEnded(@{});
+    }
 }
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    [super touchesCancelled:touches withEvent:event];
+    if (self.onTouchesEnded) {
+        self.onTouchesEnded(@{});
+    }
+}
+
 
 @end

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -33,6 +33,15 @@
                                               [_playerViewController.view.leftAnchor constraintEqualToAnchor:self.leftAnchor],
                                               [_playerViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
                                               ]];
+    
+    // Add Gesture Recognizers
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap:)];
+    tap.numberOfTapsRequired = 1;
+    [self addGestureRecognizer:tap];
+    
+    UITapGestureRecognizer *doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(doubleTap:)];
+    doubleTap.numberOfTapsRequired = 2;
+    [self addGestureRecognizer:doubleTap];
 
     _targetVolume = 1.0;
     _autoPlay = NO;
@@ -281,5 +290,16 @@
     }
 }
 
+- (void)tap: (UITapGestureRecognizer *)gesture {
+    if(self.onTap) {
+        self.onTap(@{});
+    }
+}
+
+- (void)doubleTap: (UITapGestureRecognizer *)gesture {
+    if(self.onDoubleTap) {
+        self.onDoubleTap(@{});
+    }
+}
 
 @end

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -269,14 +269,16 @@
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [super touchesEnded:touches withEvent:event];
     if (self.onTouchesEnded) {
-        self.onTouchesEnded(@{@"tapCount" : @([touches anyObject].tapCount)});
+        NSUInteger taps = [[[event allTouches] anyObject] tapCount];
+        self.onTouchesEnded(@{@"tapCount" : @(taps)});
     }
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [super touchesCancelled:touches withEvent:event];
     if (self.onTouchesEnded) {
-        self.onTouchesEnded(@{@"tapCount" : @([touches anyObject].tapCount)});
+        NSUInteger taps = [[[event allTouches] anyObject] tapCount];
+        self.onTouchesEnded(@{@"tapCount" : @(taps)});
     }
 }
 

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -254,4 +254,16 @@
     [self.playbackController setVideos:@[]];
 }
 
+#pragma mark UIView Methods
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    NSLog("touches began");
+    self.onTouchesBegan();
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
+    NSLog("touches ended");
+    self.onTouchesEnded();
+}
+
 @end

--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -33,16 +33,6 @@
                                               [_playerViewController.view.leftAnchor constraintEqualToAnchor:self.leftAnchor],
                                               [_playerViewController.view.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
                                               ]];
-    
-    // Add Gesture Recognizers
-    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tap:)];
-    tap.numberOfTapsRequired = 1;
-    [self addGestureRecognizer:tap];
-    
-    UITapGestureRecognizer *doubleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(doubleTap:)];
-    doubleTap.numberOfTapsRequired = 2;
-    [self addGestureRecognizer:doubleTap];
-
     _targetVolume = 1.0;
     _autoPlay = NO;
 }
@@ -279,26 +269,14 @@
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [super touchesEnded:touches withEvent:event];
     if (self.onTouchesEnded) {
-        self.onTouchesEnded(@{});
+        self.onTouchesEnded(@{@"tapCount" : @([touches anyObject].tapCount)});
     }
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [super touchesCancelled:touches withEvent:event];
     if (self.onTouchesEnded) {
-        self.onTouchesEnded(@{});
-    }
-}
-
-- (void)tap: (UITapGestureRecognizer *)gesture {
-    if(self.onTap) {
-        self.onTap(@{});
-    }
-}
-
-- (void)doubleTap: (UITapGestureRecognizer *)gesture {
-    if(self.onDoubleTap) {
-        self.onDoubleTap(@{});
+        self.onTouchesEnded(@{@"tapCount" : @([touches anyObject].tapCount)});
     }
 }
 

--- a/ios/BrightcovePlayerManager.m
+++ b/ios/BrightcovePlayerManager.m
@@ -37,6 +37,8 @@ RCT_EXPORT_VIEW_PROPERTY(onChangeDuration, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onUpdateBufferProgress, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onEnterFullscreen, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onExitFullscreen, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onTouchesBegan, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onTouchesEnded, RCTDirectEventBlock);
 
 RCT_EXPORT_METHOD(seekTo:(nonnull NSNumber *)reactTag seconds:(nonnull NSNumber *)seconds) {
     [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -82,14 +82,6 @@ class BrightcovePlayer extends Component {
           this.props.onTouchesEnded &&
           this.props.onTouchesEnded(event.nativeEvent)
         }
-        onTap={event =>
-          this.props.onTap &&
-          this.props.onTap(event.nativeEvent)
-        }
-        onDoubleTap={event =>
-          this.props.onDoubleTap &&
-          this.props.onDoubleTap(event.nativeEvent)
-        }
         onToggleAndroidFullscreen={event => {
           const fullscreen =
             typeof event.nativeEvent.fullscreen === 'boolean'
@@ -151,9 +143,7 @@ BrightcovePlayer.propTypes = {
   onEnterFullscreen: PropTypes.func,
   onExitFullscreen: PropTypes.func,
   onTouchesBegan: PropTypes.func,
-  onTouchesEnded: PropTypes.func,
-  onTap: PropTypes.func,
-  onDoubleTap: PropTypes.func
+  onTouchesEnded: PropTypes.func
 };
 
 BrightcovePlayer.defaultProps = {};

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -82,6 +82,14 @@ class BrightcovePlayer extends Component {
           this.props.onTouchesEnded &&
           this.props.onTouchesEnded(event.nativeEvent)
         }
+        onTap={event =>
+          this.props.onTap &&
+          this.props.onTap(event.nativeEvent)
+        }
+        onDoubleTap={event =>
+          this.props.onDoubleTap &&
+          this.props.onDoubleTap(event.nativeEvent)
+        }
         onToggleAndroidFullscreen={event => {
           const fullscreen =
             typeof event.nativeEvent.fullscreen === 'boolean'
@@ -143,7 +151,9 @@ BrightcovePlayer.propTypes = {
   onEnterFullscreen: PropTypes.func,
   onExitFullscreen: PropTypes.func,
   onTouchesBegan: PropTypes.func,
-  onTouchesEnded: PropTypes.func
+  onTouchesEnded: PropTypes.func,
+  onTap: PropTypes.func,
+  onDoubleTap: PropTypes.func
 };
 
 BrightcovePlayer.defaultProps = {};

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -82,6 +82,14 @@ class BrightcovePlayer extends Component {
           this.props.onTouchesEnded &&
           this.props.onTouchesEnded(event.nativeEvent)
         }
+        onShowMediaControls={event =>
+          this.props.onShowMediaControls &&
+          this.props.onShowMediaControls(event.nativeEvent)
+        }
+        onHideMediaControls={event =>
+          this.props.onHideMediaControls &&
+          this.props.onHideMediaControls(event.nativeEvent)
+        }
         onToggleAndroidFullscreen={event => {
           const fullscreen =
             typeof event.nativeEvent.fullscreen === 'boolean'
@@ -143,7 +151,9 @@ BrightcovePlayer.propTypes = {
   onEnterFullscreen: PropTypes.func,
   onExitFullscreen: PropTypes.func,
   onTouchesBegan: PropTypes.func,
-  onTouchesEnded: PropTypes.func
+  onTouchesEnded: PropTypes.func,
+  onShowMediaControls: PropTypes.func,
+  onHideMediaControls: PropTypes.func
 };
 
 BrightcovePlayer.defaultProps = {};

--- a/src/BrightcovePlayer.js
+++ b/src/BrightcovePlayer.js
@@ -74,6 +74,14 @@ class BrightcovePlayer extends Component {
           this.props.onExitFullscreen &&
           this.props.onExitFullscreen(event.nativeEvent)
         }
+        onTouchesBegan={event =>
+          this.props.onTouchesBegan &&
+          this.props.onTouchesBegan(event.nativeEvent)
+        }
+        onTouchesEnded={event =>
+          this.props.onTouchesEnded &&
+          this.props.onTouchesEnded(event.nativeEvent)
+        }
         onToggleAndroidFullscreen={event => {
           const fullscreen =
             typeof event.nativeEvent.fullscreen === 'boolean'
@@ -133,7 +141,9 @@ BrightcovePlayer.propTypes = {
   onChangeDuration: PropTypes.func,
   onUpdateBufferProgress: PropTypes.func,
   onEnterFullscreen: PropTypes.func,
-  onExitFullscreen: PropTypes.func
+  onExitFullscreen: PropTypes.func,
+  onTouchesBegan: PropTypes.func,
+  onTouchesEnded: PropTypes.func
 };
 
 BrightcovePlayer.defaultProps = {};


### PR DESCRIPTION
This PR adds support for detecting when the media controls are shown / hidden on iOS and Android. This allows us to display a close button in React Native that closely mimics the video player controls.

On iOS this is done through `onTouchesBegan` and `onTouchesEnded`. There is no great way I could find to detect directly when the native controls are hidden / shown, so instead we can detect when the user started interacting with the video player and try to duplicate the behavior of the native controls.

On Android we can listen for the `HIDE_MEDIA_CONTROLS` and `SHOW_MEDIA_CONTROLS` event for a much easier implementation.

Notes:
- On Android I also adjusted how the video player scales. It will now scale to fill the screen's height. This should prevent black bars from appearing on most devices. If we need to adjust it for more square devices we can do another pass.
- On Android I also removed the `simulateLandscape` functionality from the native player now that we are rotating the app through React Native.