### PR TITLE
Bugfix: context is not activity context

### DIFF
--- a/android/src/main/java/jp/manse/BrightcovePlayerView.java
+++ b/android/src/main/java/jp/manse/BrightcovePlayerView.java
@@ -73,7 +73,7 @@ public class BrightcovePlayerView extends RelativeLayout implements LifecycleEve
         this.applicationContext.addLifecycleEventListener(this);
         this.setBackgroundColor(Color.BLACK);
 
-        this.playerVideoView = new BrightcoveExoPlayerTextureVideoView(this.context);
+        this.playerVideoView = new BrightcoveExoPlayerTextureVideoView(context.getCurrentActivity());
         this.addView(this.playerVideoView);
         this.playerVideoView.setLayoutParams(new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
         this.playerVideoView.finishInitialization();

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -57,3 +57,5 @@ buck-out/
 
 # CocoaPods
 /ios/Pods/
+
+.env

--- a/example/App.js
+++ b/example/App.js
@@ -1,16 +1,16 @@
 import React, { Component } from 'react';
 import { FlatList, StatusBar, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { BrightcovePlayer, BrightcovePlayerPoster, BrightcovePlayerUtil } from 'react-native-brightcove-player';
+import Config from "react-native-config";
 
-const ACCOUNT_ID = '5434391461001';
-const POLICY_KEY =
-  'BCpkADawqM0T8lW3nMChuAbrcunBBHmh4YkNl5e6ZrKQwPiK_Y83RAOF4DP5tyBF_ONBVgrEjqW6fbV0nKRuHvjRU3E8jdT9WMTOXfJODoPML6NUDCYTwTHxtNlr5YdyGYaCPLhMUZ3Xu61L';
-const PLAYLIST_REF_ID = 'brightcove-native-sdk-plist';
-
-// const ACCOUNT_ID = '6111983544001';
+// const ACCOUNT_ID = '5434391461001';
 // const POLICY_KEY =
-//   'BCpkADawqM3mIw2gEyYJ26qTlDZpBBB7G56vaHlkPDKmwpUQHjsi42l3vvySqov0xFDSn4cLxMKyKAIjHEj3FIv3DUP-t2gKRiNpM0Ag2g7k7aHjbjrv0N5w2ha-0RZTYQ3yqxB1kMgqi0Vu';
-// const PLAYLIST_REF_ID = '12345';
+//   'BCpkADawqM0T8lW3nMChuAbrcunBBHmh4YkNl5e6ZrKQwPiK_Y83RAOF4DP5tyBF_ONBVgrEjqW6fbV0nKRuHvjRU3E8jdT9WMTOXfJODoPML6NUDCYTwTHxtNlr5YdyGYaCPLhMUZ3Xu61L';
+// const PLAYLIST_REF_ID = 'brightcove-native-sdk-plist';
+
+const ACCOUNT_ID = Config.BC_ACCOUNT_ID;
+const POLICY_KEY = Config.BC_POLICY_KEY;
+const PLAYLIST_REF_ID = Config.BC_PLAYLIST_REF_ID;
 
 var hack = 0;
 
@@ -65,6 +65,14 @@ export default class App extends Component {
     const downloadStatus = this.state.offlineVideos.find(
       video => video.videoId === item.videoId
     );
+    if (item.videoId) {
+        this.setState({
+            playback: {
+                videoId: item.videoId
+            }
+        });
+        return;
+    }
     this.setState({
       playback:
         downloadStatus && downloadStatus.downloadProgress === 1
@@ -86,7 +94,7 @@ export default class App extends Component {
   }
 
   componentWillUnmount() {
-    this.disposer && this.disposer();
+    this.disposer && this.disposer.remove();
   }
 
   render() {
@@ -94,7 +102,7 @@ export default class App extends Component {
       <View style={styles.container}>
         <StatusBar barStyle="light-content" />
         {
-            this.state.playback.referenceId &&
+            (this.state.playback.referenceId || this.state.playback.videoId || this.state.playback.videoToken) &&
             <BrightcovePlayer
               style={styles.video}
               accountId={ACCOUNT_ID}

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -7068,6 +7068,11 @@
         }
       }
     },
+    "react-native-config": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-config/-/react-native-config-1.0.0.tgz",
+      "integrity": "sha512-ZydFNkGgjPCgJ4nDDGxuoMSsz4HACJH6TyYEDeefnzGW3XS/HXxdiW8SOaOD8B0WACQJHM028ypnwhexJ7hhsA=="
+    },
     "react-refresh": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.4.2.tgz",

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "0.61.2",
-    "react-native-brightcove-player": "1.7.0"
+    "react-native-brightcove-player": "1.7.0",
+    "react-native-config": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.6.4",


### PR DESCRIPTION
Brightcove complains (only on certain devices, may be an android 9 thing) that the context passed in to the brightcove player view isn't an activity, because it's a themed react context.