### PR TITLE
iOS - Ignore onTouchesEnded

### DIFF
--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -268,10 +268,6 @@
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     [super touchesEnded:touches withEvent:event];
-    if (self.onTouchesEnded) {
-        NSUInteger taps = [[[event allTouches] anyObject] tapCount];
-        self.onTouchesEnded(@{@"tapCount" : @(taps)});
-    }
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {


### PR DESCRIPTION
This PR fixes an issue where `touchesEnded` would be fired when a user swipes on the video player. We only really want to respond to taps inorder to sync up the RN close button with the AVPlayerView controls. A tap seems to trigger `touchesCancelled` so we can safely ignore `touchesEnded` for now.