### PR TITLE
iOS - Fairplay Download

### DIFF
--- a/ios/BrightcovePlayerUtil.m
+++ b/ios/BrightcovePlayerUtil.m
@@ -173,6 +173,10 @@ RCT_EXPORT_METHOD(getPlaylistWithReferenceId:(NSString *)referenceId accountId:(
 - (NSDictionary *)generateDownloadParameterWithBitRate:(NSNumber*)bitRate {
     return
     @{
+      // Purchase license
+      kBCOVFairPlayLicensePurchaseKey: @(YES),
+        
+      // Specify variant using the bitrate
       kBCOVOfflineVideoManagerRequestedBitrateKey: bitRate
       };
 }


### PR DESCRIPTION
This PR adds support for downloading Fairplay videos. This was achieved by adding `kBCOVFairPlayLicensePurchaseKey` to the request params.