### PR TITLE
Enable Airplay on iOS

### DIFF
--- a/ios/BrightcovePlayer.m
+++ b/ios/BrightcovePlayer.m
@@ -22,6 +22,8 @@
     [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryPlayback error:nil];
 
     _playbackController = [self createPlaybackController];
+    _playbackController.allowsExternalPlayback = true;
+    _playbackController.usesExternalPlaybackWhileExternalScreenIsActive = true;
     _playbackController.delegate = self;
     _playbackController.autoPlay = NO;
     _playbackController.autoAdvance = YES;


### PR DESCRIPTION
Adds `allowsExternalPlayback` and `usesExternalPlaybackWhileExternalScreenIsActive` to the BVOCPlaybackController. This should enable Airplay to work as expected.